### PR TITLE
Allow installation without setup and enabling

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -19,7 +19,7 @@ class ss_sentinel_one::agent inherits ::ss_sentinel_one {
   }
 
   # The setup and configuration utilises the custom facts
-  if $facts['sentinel_one'] != 'Enabled' {
+  if $ss_sentinel_one::enable and $ss_sentinel_one::site_token != '' and $facts['sentinel_one'] != 'Enabled' {
     if $ss_sentinel_one::http_proxy != '' {
       exec { 'management_proxy':
         command => "sentinelctl management proxy set ${ss_sentinel_one::http_proxy}",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,8 @@
 class ss_sentinel_one (
-  $site_token,
   $download_url,
+  $site_token = '',
   $http_proxy = '',
+  $enable = true,
 ) {
   class { 'ss_sentinel_one::agent': }
 }


### PR DESCRIPTION
Enabling agent after installation will cause issues with Silverstripe Cloud.

Configuration and enabling client needs to be done as part of the release process as each server needs to register with portal to get unique UUID.